### PR TITLE
Restore auth context

### DIFF
--- a/firebase/config.js
+++ b/firebase/config.js
@@ -1,65 +1,14 @@
-// import firebase from "firebase/compat/app";
-// import "firebase/compat/auth";
-// import "firebase/compat/firestore";
-// import "firebase/compat/storage";
-// import Constants from 'expo-constants';
-
-// // Environment variables are injected via app.config.js. Access them from
-// // Constants.expoConfig.extra without destructuring to avoid name collisions
-// // Try multiple sources so the app works in Expo Go, web, or a native build
-// // `expoConfig.extra` is available in development. `manifest.extra` covers
-// // EAS build environments. Finally, fall back to `process.env` when running in
-// // Node-based tooling.
-// const extra =
-//   Constants.expoConfig?.extra ||
-//   Constants.manifest?.extra ||
-//   process.env;
-
-
-// // Environment variables are injected via app.config.js. Access them from
-// // Constants.expoConfig.extra without destructuring to avoid name collisions
-
-
-// // Environment variables are injected via app.config.js. Access them from
-// // Constants.expoConfig.extra without destructuring to avoid name collisions
-
-
-// // Environment variables are injected via app.config.js into Constants.expoConfig.extra
-
-// // Environment variables are injected via app.config.js into Constants.expoConfig.extra
-
-// const {
-//   FIREBASE_API_KEY,
-//   FIREBASE_AUTH_DOMAIN,
-//   FIREBASE_PROJECT_ID,
-//   FIREBASE_STORAGE_BUCKET,
-//   FIREBASE_MESSAGING_SENDER_ID,
-//   FIREBASE_APP_ID,
-// } = Constants.expoConfig?.extra ?? {};
-// const firebaseConfig = {
-
-//   apiKey: "AIzaSyD7GCjiwy7mDtvWK9vRPu5m2bzRbLcZWzw",
-//   authDomain: "to-do-list-b831f.firebaseapp.com",
-//   projectId: "to-do-list-b831f",
-//   storageBucket: "to-do-list-b831f.firebasestorage.app",
-//   messagingSenderId: "1045803774649",
-//   appId: "1:1045803774649:web:1609b1efe7571daf4c6168",
-// }
-
-
-// if (!firebase.apps.length) {
-//   firebase.initializeApp(firebaseConfig);
-// }
-
-// export { firebase };
-
-// firebase/config.js
+import firebase from 'firebase/compat/app';
+import 'firebase/compat/auth';
+import 'firebase/compat/firestore';
+import 'firebase/compat/storage';
 import Constants from 'expo-constants';
-import { initializeApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
 import { getFirestore } from 'firebase/firestore';
 import { getStorage } from 'firebase/storage';
+import { initializeAppCheck, ReCaptchaV3Provider } from 'firebase/app-check';
 
+// Resolve env vars from Expo config or process.env for Node tools
 const extra =
   Constants.expoConfig?.extra ||
   Constants.manifest?.extra ||
@@ -74,8 +23,27 @@ const firebaseConfig = {
   appId: extra.FIREBASE_APP_ID,
 };
 
-const app = initializeApp(firebaseConfig);
+// Initialize once for both compat and modular APIs
+const app = firebase.apps.length
+  ? firebase.app()
+  : firebase.initializeApp(firebaseConfig);
 
+// Initialize Firebase App Check in browser environments
+if (typeof window !== 'undefined') {
+  try {
+    initializeAppCheck(app, {
+      provider: new ReCaptchaV3Provider(extra.RECAPTCHA_KEY),
+      isTokenAutoRefreshEnabled: true,
+    });
+  } catch (err) {
+    // ignore duplicate initialization errors
+  }
+}
+
+// Export compat instance for existing code
+export { firebase };
+
+// Export modular helpers for new code
 export const auth = getAuth(app);
 export const db = getFirestore(app);
 export const storage = getStorage(app);

--- a/screens/Auth/LoginScreen.js
+++ b/screens/Auth/LoginScreen.js
@@ -28,7 +28,6 @@ export default function LoginScreen({ navigation }) {
       const { user } = await login(email.trim(), password);
       console.log('✅ Signed in:', user.uid);
       await registerForPushNotificationsAsync();
-      navigation.replace('Tasks');
     } catch (err) {
       console.error('🔴 Firebase login error:', err.code, err.message);
       Alert.alert('Login Error', err.message);

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -1,54 +1,52 @@
-// import React, { createContext, useState, useEffect } from 'react';
-// import { firebase } from '../firebase/config';
+import React, { createContext, useState, useEffect } from 'react';
+import { firebase, auth, db } from '../firebase/config';
+import { onAuthStateChanged } from 'firebase/auth';
+import { doc, getDoc } from 'firebase/firestore';
 
-// export const AuthContext = createContext();
+export const AuthContext = createContext();
 
-// /**
-//  * Wrap your app in <AuthProvider> to get { user, role, loading } everywhere.
-//  */
-// export function AuthProvider({ children }) {
-//     const [user, setUser] = useState(null);
-//     const [role, setRole] = useState('');
-//     const [loading, setLoading] = useState(true);
+/**
+ * Wrap your app in <AuthProvider> to get { user, role, loading } everywhere.
+ */
+export function AuthProvider({ children }) {
+    const [user, setUser] = useState(null);
+    const [role, setRole] = useState('');
+    const [loading, setLoading] = useState(true);
 
-//     useEffect(() => {
-//         // Listen for auth state changes
-//         const unsubscribe = firebase.auth().onAuthStateChanged(async u => {
-//             setUser(u);
-//             if (u) {
-//                 // Load role from Firestore
-//                 const snap = await firebase
-//                     .firestore()
-//                     .collection('users')
-//                     .doc(u.uid)
-//                     .get();
-//                 setRole(snap.data()?.role || '');
-//             } else {
-//                 setRole('');
-//             }
-//             setLoading(false);
-//         });
-//         return unsubscribe;
-//     }, []);
+    useEffect(() => {
+        // Listen for auth state changes using modular API
+        const unsubscribe = onAuthStateChanged(auth, async (u) => {
+            setUser(u);
+            if (u) {
+                // Load role from Firestore
+                try {
+                    const snap = await getDoc(doc(db, 'users', u.uid));
+                    setRole(snap.exists() ? snap.data().role || '' : '');
+                } catch {
+                    setRole('');
+                }
+            } else {
+                setRole('');
+            }
+            setLoading(false);
+        });
+        return unsubscribe;
+    }, []);
 
-//     return (
-//         <AuthContext.Provider value={{ user, role, loading }}>
-//             {children}
-//         </AuthContext.Provider>
-//     );
-// }
-// utils/auth.js
+    return (
+        <AuthContext.Provider value={{ user, role, loading }}>
+            {children}
+        </AuthContext.Provider>
+    );
+}
 
-// utils/auth.js
 import {
-    onAuthStateChanged,
     signInWithEmailAndPassword,
     createUserWithEmailAndPassword,
     sendEmailVerification,
     reload,
     signOut,
 } from 'firebase/auth';
-import { auth } from '../firebase/config';
 
 /** Subscribe to auth changes; returns unsubscribe() */
 export function listenAuth(cb) {


### PR DESCRIPTION
## Summary
- restore `AuthProvider` for global auth context
- provide Firebase compat exports alongside modular helpers
- add Firebase App Check initialization and clean login navigation
- use modular API to listen for auth state changes without relying on compat auth

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686cea04df70832ab7d235c18301234d