### PR TITLE
Fix duplicate import causing bundle error

### DIFF
--- a/screens/Tasks/TaskDetailScreen.js
+++ b/screens/Tasks/TaskDetailScreen.js
@@ -12,7 +12,6 @@ import { firebase } from '../../firebase/config';
 import sendNotification from '../../utils/sendNotification';
 
 import { AuthContext } from '../../utils/auth';
-import sendNotification from '../../utils/sendNotification';
 
 export default function TaskDetailScreen({ route, navigation }) {
   const { taskId } = route.params;


### PR DESCRIPTION
## Summary
- remove duplicate `sendNotification` import in `TaskDetailScreen`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686d161657c0832a8c560dea8dfd2d0b