### PR TITLE
Implement role-based Firebase flows

### DIFF
--- a/firebase/config.js
+++ b/firebase/config.js
@@ -1,8 +1,5 @@
-import firebase from 'firebase/compat/app';
-import 'firebase/compat/auth';
-import 'firebase/compat/firestore';
-import 'firebase/compat/storage';
 import Constants from 'expo-constants';
+import { initializeApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
 import { getFirestore } from 'firebase/firestore';
 import { getStorage } from 'firebase/storage';
@@ -14,21 +11,18 @@ const extra =
   Constants.manifest?.extra ||
   process.env;
 
-
 const firebaseConfig = {
-  apiKey: FIREBASE_API_KEY,
-  authDomain: FIREBASE_AUTH_DOMAIN,
-  projectId: FIREBASE_PROJECT_ID,
-  storageBucket: FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: FIREBASE_MESSAGING_SENDER_ID,
-  appId: FIREBASE_APP_ID,
-  measurementId: FIREBASE_MEASUREMENT_ID,
+  apiKey: extra.FIREBASE_API_KEY,
+  authDomain: extra.FIREBASE_AUTH_DOMAIN,
+  projectId: extra.FIREBASE_PROJECT_ID,
+  storageBucket: extra.FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: extra.FIREBASE_MESSAGING_SENDER_ID,
+  appId: extra.FIREBASE_APP_ID,
+  measurementId: extra.FIREBASE_MEASUREMENT_ID,
 };
 
-// Initialize once for both compat and modular APIs
-const app = firebase.apps.length
-  ? firebase.app()
-  : firebase.initializeApp(firebaseConfig);
+// Initialize Firebase app
+const app = initializeApp(firebaseConfig);
 
 // Initialize Firebase App Check in browser environments
 if (typeof window !== 'undefined') {
@@ -37,15 +31,13 @@ if (typeof window !== 'undefined') {
       provider: new ReCaptchaV3Provider(extra.RECAPTCHA_KEY),
       isTokenAutoRefreshEnabled: true,
     });
-  } catch (err) {
-    // ignore duplicate initialization errors
+  } catch {
+    // ignore duplicate initialization
   }
 }
 
-// Export compat instance for existing code
-export { firebase };
-
-// Export modular helpers for new code
+// Export app and modular helpers
+export { app };
 export const auth = getAuth(app);
 export const db = getFirestore(app);
 export const storage = getStorage(app);

--- a/screens/Dashboard/AdminDashboard.js
+++ b/screens/Dashboard/AdminDashboard.js
@@ -1,29 +1,33 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useContext } from 'react';
 import {
     View,
     FlatList,
-    Button,
     StyleSheet,
     ActivityIndicator
 } from 'react-native';
-import { firebase } from '../../firebase/config';
+import { FAB } from 'react-native-paper';
+import { collection, query, where, onSnapshot } from 'firebase/firestore';
+import { auth, db } from '../../firebase/config';
+import { AuthContext } from '../../utils/auth';
 import TaskCard from '../../components/TaskCard';
 
 export default function AdminDashboard({ navigation }) {
+    const { role } = useContext(AuthContext);
     const [tasks, setTasks] = useState([]);
     const [loading, setLoading] = useState(true);
 
     useEffect(() => {
-        const uid = firebase.auth().currentUser.uid;
-        const unsub = firebase
-            .firestore()
-            .collection('tasks')
-            .where('assigneeType', '==', 'admin')
-            .where('assigneeId', '==', uid)
-            .onSnapshot((snap) => {
-                setTasks(snap.docs.map((d) => ({ id: d.id, ...d.data() })));
-                setLoading(false);
-            });
+        const uid = auth.currentUser.uid;
+        // fetch tasks assigned to this admin using the modular query API
+        const q = query(
+            collection(db, 'tasks'),
+            where('assignedType', '==', 'admin'),
+            where('assignedTo', '==', uid)
+        );
+        const unsub = onSnapshot(q, (snap) => {
+            setTasks(snap.docs.map((d) => ({ id: d.id, ...d.data() })));
+            setLoading(false);
+        });
         return unsub;
     }, []);
 
@@ -39,21 +43,25 @@ export default function AdminDashboard({ navigation }) {
 
     return (
         <View style={styles.container}>
-            <Button
-                title="Create Task"
-                onPress={() => navigation.navigate('CreateTask')}
-                color="#d32f2f"
-            />
             <FlatList
                 data={tasks}
                 keyExtractor={(i) => i.id}
                 renderItem={({ item }) => <TaskCard task={item} />}
             />
+            {(role === 'admin' || role === 'superadmin') && (
+                <FAB
+                    style={styles.fab}
+                    icon="plus"
+                    label="Create Task"
+                    onPress={() => navigation.navigate('CreateTask')}
+                />
+            )}
         </View>
     );
 }
 
 const styles = StyleSheet.create({
     container: { flex: 1, padding: 10, backgroundColor: '#fff' },
-    center: { flex: 1, justifyContent: 'center', alignItems: 'center' }
+    center: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+    fab: { position: 'absolute', right: 16, bottom: 16, backgroundColor: '#d32f2f' }
 });

--- a/screens/Tasks/CreateTaskScreen.js
+++ b/screens/Tasks/CreateTaskScreen.js
@@ -1,175 +1,28 @@
-// // screens/tasks/CreateTaskScreen.js
-// import React, { useEffect, useState, useContext } from 'react';
-// import { View, StyleSheet, TextInput, Platform, ScrollView } from 'react-native';
-// import { Text, Button, RadioButton } from 'react-native-paper';
-// import DateTimePicker from '@react-native-community/datetimepicker';
-// import { getFirestore, collection, addDoc, query, where, getDocs } from 'firebase/firestore';
-// import { AuthContext } from '../../utils/auth';
-// import sendNotification from '../../utils/sendNotification';
-
-// export default function CreateTaskScreen({ navigation }) {
-//   const db = getFirestore();
-//   const { user, role } = useContext(AuthContext);
-
-//   const [title, setTitle] = useState('');
-//   const [desc, setDesc] = useState('');
-//   const [assigneeType, setAssigneeType] = useState('user');
-//   const [admins, setAdmins] = useState([]);
-//   const [users, setUsers] = useState([]);
-//   const [selectedAdmin, setSelectedAdmin] = useState(null);
-//   const [selectedUser, setSelectedUser] = useState(null);
-//   const [deadline, setDeadline] = useState(new Date());
-//   const [showPicker, setShowPicker] = useState(false);
-
-//   useEffect(() => {
-//     // superadmin sees admins
-//     if (role === 'superadmin') {
-//       (async () => {
-//         const q = query(collection(db, 'users'), where('role', '==', 'admin'));
-//         const snap = await getDocs(q);
-//         setAdmins(snap.docs.map(d => ({ id: d.id, ...d.data() })));
-//       })();
-//     }
-//     // admin/superadmin sees their users
-//     if (role === 'admin' || role === 'superadmin') {
-//       (async () => {
-//         const q = query(collection(db, 'users'), where('adminId', '==', user.uid));
-//         const snap = await getDocs(q);
-//         setUsers(snap.docs.map(d => ({ id: d.id, ...d.data() })));
-//       })();
-//     }
-//   }, []);
-
-//   async function onSubmit() {
-//     const assigneeId = assigneeType === 'admin' ? selectedAdmin : selectedUser;
-//     if (!title || !assigneeId) return;
-
-//     const taskRef = await addDoc(collection(db, 'tasks'), {
-//       title,
-//       desc,
-//       status: 'todo',
-//       deadline,
-//       createdBy: user.uid,
-//       assignedType: assigneeType,
-//       assignedTo: assigneeId,
-//       createdAt: new Date()
-//     });
-
-//     // notify the assignee
-//     await sendNotification({
-//       userId: assigneeId,
-//       taskId: taskRef.id,
-//       type: 'assigned',
-//       message: `New task "${title}" assigned to you.`
-//     });
-
-//     // if superadmin → user, also notify that user’s admin
-//     if (role === 'superadmin' && assigneeType === 'user') {
-//       const adminOfUser = users.find(u => u.id === assigneeId)?.adminId;
-//       if (adminOfUser) {
-//         await sendNotification({
-//           userId: adminOfUser,
-//           taskId: taskRef.id,
-//           type: 'assigned',
-//           message: `Your user has a new task: "${title}".`
-//         });
-//       }
-//     }
-
-//     navigation.goBack();
-//   }
-
-//   return (
-//     <ScrollView style={s.container}>
-//       <Text style={s.header}>Create New Task</Text>
-
-//       <TextInput
-//         placeholder="Title"
-//         style={s.input}
-//         value={title} onChangeText={setTitle}
-//       />
-
-//       <TextInput
-//         placeholder="Description"
-//         style={[s.input, { height: 80 }]}
-//         value={desc} onChangeText={setDesc}
-//         multiline
-//       />
-
-//       <Text style={s.label}>Assign to:</Text>
-//       <RadioButton.Group onValueChange={setAssigneeType} value={assigneeType}>
-//         {role === 'superadmin' && (
-//           <View style={s.radioRow}>
-//             <RadioButton value="admin" /><Text>Admin</Text>
-//           </View>
-//         )}
-//         <View style={s.radioRow}>
-//           <RadioButton value="user" /><Text>User</Text>
-//         </View>
-//       </RadioButton.Group>
-
-//       {assigneeType === 'admin' && admins.map(a => (
-//         <Button
-//           key={a.id}
-//           mode={selectedAdmin === a.id ? 'contained' : 'outlined'}
-//           onPress={() => setSelectedAdmin(a.id)}
-//         >
-//           {a.name || a.email}
-//         </Button>
-//       ))}
-
-//       {assigneeType === 'user' && users.map(u => (
-//         <Button
-//           key={u.id}
-//           mode={selectedUser === u.id ? 'contained' : 'outlined'}
-//           onPress={() => setSelectedUser(u.id)}
-//         >
-//           {u.name || u.email}
-//         </Button>
-//       ))}
-
-//       <Text style={s.label}>Deadline:</Text>
-//       <Button onPress={() => setShowPicker(true)}>
-//         {deadline.toLocaleDateString()} {deadline.toLocaleTimeString()}
-//       </Button>
-//       {showPicker && (
-//         <DateTimePicker
-//           value={deadline}
-//           mode="datetime"
-//           display={Platform.OS === 'ios' ? 'spinner' : 'default'}
-//           onChange={(_, d) => {
-//             setShowPicker(Platform.OS === 'ios');
-//             if (d) setDeadline(d);
-//           }}
-//         />
-//       )}
-
-//       <Button style={s.submit} mode="contained" onPress={onSubmit}>
-//         Create Task
-//       </Button>
-//     </ScrollView>
-//   );
-// }
-
-// const s = StyleSheet.create({
-//   container: { flex: 1, padding: 16, backgroundColor: '#fafafa' },
-//   header:    { fontSize: 24, fontWeight: 'bold', marginBottom: 12, color: '#D32F2F' },
-//   label:     { marginTop: 12, fontWeight: '600' },
-//   input:     { borderWidth: 1, borderColor: '#DDD', borderRadius: 6, padding: 8, marginVertical: 6 },
-//   radioRow:  { flexDirection: 'row', alignItems: 'center', marginVertical: 4 },
-//   submit:    { marginTop: 24, backgroundColor: '#D32F2F' },
-// });
-// screens/tasks/CreateTaskScreen.js
 import React, { useEffect, useState, useContext } from 'react';
-import { View, StyleSheet, TextInput, Platform, ScrollView } from 'react-native';
-import { Text, Button, RadioButton } from 'react-native-paper';
+import {
+  View,
+  StyleSheet,
+  TextInput,
+  Platform,
+  ScrollView,
+  Text,
+  Button,
+} from 'react-native';
+import { RadioButton } from 'react-native-paper';
 import DateTimePicker from '@react-native-community/datetimepicker';
-import { getFirestore, collection, addDoc, query, where, getDocs } from 'firebase/firestore';
+import {
+  collection,
+  addDoc,
+  query,
+  where,
+  getDocs,
+  serverTimestamp,
+} from 'firebase/firestore';
+import { db } from '../../firebase/config';
 import { AuthContext } from '../../utils/auth';
 import sendNotification from '../../utils/sendNotification';
 
 export default function CreateTaskScreen({ navigation }) {
-  const db = getFirestore();
   const { user, role } = useContext(AuthContext);
 
   const [title, setTitle] = useState('');
@@ -183,23 +36,25 @@ export default function CreateTaskScreen({ navigation }) {
   const [showPicker, setShowPicker] = useState(false);
 
   useEffect(() => {
-    // superadmin sees admins
     if (role === 'superadmin') {
       (async () => {
-        const q = query(collection(db, 'users'), where('role', '==', 'admin'));
-        const snap = await getDocs(q);
-        setAdmins(snap.docs.map(d => ({ id: d.id, ...d.data() })));
+        const snap = await getDocs(query(collection(db, 'users'), where('role', '==', 'admin')));
+        setAdmins(snap.docs.map((d) => ({ id: d.id, ...d.data() })));
       })();
-    }
-    // admin/superadmin sees their users
-    if (role === 'admin' || role === 'superadmin') {
+
       (async () => {
-        const q = query(collection(db, 'users'), where('adminId', '==', user.uid));
-        const snap = await getDocs(q);
-        setUsers(snap.docs.map(d => ({ id: d.id, ...d.data() })));
+        const snap = await getDocs(query(collection(db, 'users'), where('role', '==', 'user')));
+        setUsers(snap.docs.map((d) => ({ id: d.id, ...d.data() })));
+      })();
+    } else if (role === 'admin') {
+      (async () => {
+        const snap = await getDocs(
+          query(collection(db, 'users'), where('adminId', '==', user.uid))
+        );
+        setUsers(snap.docs.map((d) => ({ id: d.id, ...d.data() })));
       })();
     }
-  }, []);
+  }, [role, user]);
 
   async function onSubmit() {
     const assigneeId = assigneeType === 'admin' ? selectedAdmin : selectedUser;
@@ -213,7 +68,7 @@ export default function CreateTaskScreen({ navigation }) {
       createdBy: user.uid,
       assignedType: assigneeType,
       assignedTo: assigneeId,
-      createdAt: new Date()
+      createdAt: serverTimestamp(),
     });
 
     // notify the assignee
@@ -269,30 +124,34 @@ export default function CreateTaskScreen({ navigation }) {
         </View>
       </RadioButton.Group>
 
-      {assigneeType === 'admin' && admins.map(a => (
-        <Button
-          key={a.id}
-          mode={selectedAdmin === a.id ? 'contained' : 'outlined'}
-          onPress={() => setSelectedAdmin(a.id)}
-        >
-          {a.name || a.email}
-        </Button>
-      ))}
+      {assigneeType === 'admin' &&
+        admins.map((a) => (
+          <View key={a.id} style={s.selectBtn}>
+            <Button
+              title={a.name || a.email}
+              color={selectedAdmin === a.id ? '#D32F2F' : undefined}
+              onPress={() => setSelectedAdmin(a.id)}
+            />
+          </View>
+        ))}
 
-      {assigneeType === 'user' && users.map(u => (
-        <Button
-          key={u.id}
-          mode={selectedUser === u.id ? 'contained' : 'outlined'}
-          onPress={() => setSelectedUser(u.id)}
-        >
-          {u.name || u.email}
-        </Button>
-      ))}
+      {assigneeType === 'user' &&
+        users.map((u) => (
+          <View key={u.id} style={s.selectBtn}>
+            <Button
+              title={u.name || u.email}
+              color={selectedUser === u.id ? '#D32F2F' : undefined}
+              onPress={() => setSelectedUser(u.id)}
+            />
+          </View>
+        ))}
 
       <Text style={s.label}>Deadline:</Text>
-      <Button onPress={() => setShowPicker(true)}>
-        {deadline.toLocaleDateString()} {deadline.toLocaleTimeString()}
-      </Button>
+      <Button
+        title={`${deadline.toLocaleDateString()} ${deadline.toLocaleTimeString()}`}
+        onPress={() => setShowPicker(true)}
+        color="#D32F2F"
+      />
       {showPicker && (
         <DateTimePicker
           value={deadline}
@@ -305,9 +164,9 @@ export default function CreateTaskScreen({ navigation }) {
         />
       )}
 
-      <Button style={s.submit} mode="contained" onPress={onSubmit}>
-        Create Task
-      </Button>
+      <View style={s.submitBtn}>
+        <Button title="Create Task" onPress={onSubmit} color="#D32F2F" />
+      </View>
     </ScrollView>
   );
 }
@@ -318,5 +177,6 @@ const s = StyleSheet.create({
   label: { marginTop: 12, fontWeight: '600' },
   input: { borderWidth: 1, borderColor: '#DDD', borderRadius: 6, padding: 8, marginVertical: 6 },
   radioRow: { flexDirection: 'row', alignItems: 'center', marginVertical: 4 },
-  submit: { marginTop: 24, backgroundColor: '#D32F2F' },
+  selectBtn: { marginVertical: 4 },
+  submitBtn: { marginTop: 24 },
 });

--- a/screens/Tasks/TaskBoard.js
+++ b/screens/Tasks/TaskBoard.js
@@ -6,7 +6,8 @@ import {
   StyleSheet,
   ActivityIndicator
 } from 'react-native';
-import { firebase } from '../../firebase/config';
+import { collection, onSnapshot } from 'firebase/firestore';
+import { db } from '../../firebase/config';
 import TaskCard from '../../components/TaskCard';
 
 export default function TaskBoard({ navigation }) {
@@ -14,19 +15,17 @@ export default function TaskBoard({ navigation }) {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const unsub = firebase
-      .firestore()
-      .collection('tasks')
-      .onSnapshot(
-        (snap) => {
-          setTasks(snap.docs.map((d) => ({ id: d.id, ...d.data() })));
-          setLoading(false);
-        },
-        (err) => {
-          console.warn(err);
-          setLoading(false);
-        }
-      );
+    const unsub = onSnapshot(
+      collection(db, 'tasks'),
+      (snap) => {
+        setTasks(snap.docs.map((d) => ({ id: d.id, ...d.data() })));
+        setLoading(false);
+      },
+      (err) => {
+        console.warn(err);
+        setLoading(false);
+      }
+    );
     return unsub;
   }, []);
 

--- a/screens/Tasks/TaskDetailScreen.js
+++ b/screens/Tasks/TaskDetailScreen.js
@@ -1,104 +1,95 @@
-import React, { useState, useEffect, useContext } from 'react';
-import {
-  View,
-  Text,
-  Button,
-  TextInput,
-  StyleSheet,
-  ActivityIndicator,
-  Alert
-} from 'react-native';
-import { firebase } from '../../firebase/config';
-import sendNotification from '../../utils/sendNotification';
-
+import React, { useEffect, useState, useContext } from 'react';
+import { View, Text, StyleSheet, ScrollView, Button, ActivityIndicator, Alert } from 'react-native';
+import { doc, getDoc, updateDoc } from 'firebase/firestore';
 import { AuthContext } from '../../utils/auth';
+import { db } from '../../firebase/config';
 import sendNotification from '../../utils/sendNotification';
 
 export default function TaskDetailScreen({ route, navigation }) {
   const { taskId } = route.params;
-  const db = getFirestore();
-  const { user, role } = useContext(AuthContext);
-
+  const { user } = useContext(AuthContext);
   const [task, setTask] = useState(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const sub = firebase
-      .firestore()
-      .collection('tasks')
-      .doc(taskId)
-      .onSnapshot((d) => setTask({ id: d.id, ...d.data() }));
-    return sub;
+    (async () => {
+      try {
+        const snap = await getDoc(doc(db, 'tasks', taskId));
+        if (snap.exists()) {
+          setTask({ id: snap.id, ...snap.data() });
+        }
+      } catch (e) {
+        Alert.alert('Error', 'Failed to load task');
+      } finally {
+        setLoading(false);
+      }
+    })();
   }, [taskId]);
 
-  const updateStatus = async (action) => {
+  async function changeStatus(newStatus) {
     if (!task) return;
     try {
       setLoading(true);
-      const newStatus =
-        action === 'accept'
-          ? 'inprogress'
-          : action === 'complete'
-          ? 'done'
-          : task.status;
-      await firebase
-        .firestore()
-        .collection('tasks')
-        .doc(taskId)
-        .update({
-          status: newStatus,
-          remarks: firebase.firestore.FieldValue.arrayUnion({
-            by: user.uid,
-            text: remarks,
-            at: firebase.firestore.FieldValue.serverTimestamp()
-          })
-        });
-      await sendNotification({
-        userId: task.createdBy,
-        type: action,
-        taskId,
-        message: `${user.email} ${action}ed "${task.title}"`,
-      });
-      await logAction(`${action}Task`, { taskId, action });
+      await updateDoc(doc(db, 'tasks', taskId), { status: newStatus });
+      setTask((t) => ({ ...t, status: newStatus }));
+
+      const message = `Task "${task.title}" is now ${newStatus}`;
+      await sendNotification({ userId: task.createdBy, taskId, type: 'status', message });
+      if (task.assignedTo) {
+        await sendNotification({ userId: task.assignedTo, taskId, type: 'status', message });
+      }
     } catch (e) {
-      Alert.alert('Error', e.message);
+      Alert.alert('Error', 'Failed to update task');
     } finally {
       setLoading(false);
-
     }
-
-    navigation.goBack();
   }
+
+  if (loading) {
+    return (
+      <View style={s.center}><ActivityIndicator size="large" color="#d32f2f" /></View>
+    );
+  }
+  if (!task) {
+    return (
+      <View style={s.center}><Text>Task not found.</Text></View>
+    );
+  }
+
+  const isAssignee = user?.uid === task.assignedTo;
+  const isCreator = user?.uid === task.createdBy;
 
   return (
     <ScrollView style={s.container}>
-      <Card>
-        <Card.Title
-          title={task.title}
-          subtitle={`Status: ${task.status.toUpperCase()}`}
-        />
-        <Card.Content>
-          <Text>Description:</Text>
-          <Text>{task.desc}</Text>
-          <Text>Deadline: {task.deadline.toDate().toLocaleString()}</Text>
-          <Text>Assigned by: {task.createdBy}</Text>
-          <Text>Assigned to: {task.assignedTo}</Text>
-        </Card.Content>
-        <Card.Actions>
-          {isAssignee && task.status === 'todo' && (
+      <Text style={s.title}>{task.title}</Text>
+      <Text style={s.label}>Description:</Text>
+      <Text>{task.desc}</Text>
+      <Text style={s.label}>Deadline:</Text>
+      <Text>{task.deadline?.toDate().toLocaleString()}</Text>
+      <Text style={s.label}>Status:</Text>
+      <Text>{task.status}</Text>
+
+      {task.status === 'todo' && (
+        <View style={s.actions}>
+          {isAssignee && (
             <>
-              <Button onPress={() => changeStatus('inprogress')}>Start</Button>
-              <Button onPress={() => changeStatus('done')}>Complete</Button>
+              <Button title="Start" onPress={() => changeStatus('inprogress')} />
+              <Button title="Complete" onPress={() => changeStatus('done')} />
             </>
           )}
-          {isCreator && task.status === 'todo' && (
-            <Button onPress={() => changeStatus('cancelled')}>Cancel</Button>
+          {isCreator && (
+            <Button title="Cancel" onPress={() => changeStatus('cancelled')} />
           )}
-        </Card.Actions>
-      </Card>
+        </View>
+      )}
     </ScrollView>
   );
 }
 
 const s = StyleSheet.create({
   container: { flex: 1, padding: 16, backgroundColor: '#fff' },
+  title: { fontSize: 20, fontWeight: 'bold', marginBottom: 12 },
+  label: { marginTop: 12, fontWeight: '600' },
+  actions: { marginTop: 24 },
+  center: { flex: 1, justifyContent: 'center', alignItems: 'center' }
 });

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -1,5 +1,5 @@
 import React, { createContext, useState, useEffect } from 'react';
-import { firebase, auth, db } from '../firebase/config';
+import { auth, db } from '../firebase/config';
 import { onAuthStateChanged } from 'firebase/auth';
 import { doc, getDoc } from 'firebase/firestore';
 
@@ -21,9 +21,9 @@ export function AuthProvider({ children }) {
                 // Load role from Firestore
                 try {
                     const snap = await getDoc(doc(db, 'users', u.uid));
-                    setRole(snap.exists() ? snap.data().role || '' : '');
+                    setRole(snap.exists() ? snap.data().role : 'user');
                 } catch {
-                    setRole('');
+                    setRole('user');
                 }
             } else {
                 setRole('');

--- a/utils/sendNotification.js
+++ b/utils/sendNotification.js
@@ -1,9 +1,11 @@
-import { firebase } from '../firebase/config';
+import { httpsCallable, getFunctions } from 'firebase/functions';
+import { app } from '../firebase/config';
 
 /**
  * Call the `sendNotification` Cloud Function.
  * @param {{userId: string, type: string, taskId: string, message: string}} payload
  */
 export default function sendNotification(payload) {
-  return firebase.functions().httpsCallable('sendNotification')(payload);
+  const fn = httpsCallable(getFunctions(app), 'sendNotification');
+  return fn(payload);
 }


### PR DESCRIPTION
## Summary
- refactor Firebase initialization to use modular SDK with App Check
- improve auth provider to load user role and default to 'user'
- clean up and finalize CreateTaskScreen
- rewrite TaskDetailScreen with status actions and notifications
- add floating action buttons in dashboards and refine task creation
- fix task field names and user fetching
- fix TaskBoard to use modular Firestore API
- clarify admin task query
- use native buttons in CreateTaskScreen for better compatibility

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686d161657c0832a8c560dea8dfd2d0b