### PR TITLE
Add profile edit screen and role-safe task creation

### DIFF
--- a/components/RoleBasedNav.js
+++ b/components/RoleBasedNav.js
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { AuthContext } from '../utils/auth';
 
-import TaskBoard            from '../screens/Tasks/TaskBoard';
+import TaskStack            from '../navigation/TaskStack';
 import ProfileScreen        from '../screens/ProfileScreen';
 import UserDashboard        from '../screens/Dashboard/UserDashboard';
 import AdminDashboard       from '../screens/Dashboard/AdminDashboard';
@@ -15,7 +15,7 @@ export default function RoleBasedNav() {
 
   return (
     <Tab.Navigator screenOptions={{ headerShown: false }}>
-      <Tab.Screen name="Tasks"   component={TaskBoard} />
+      <Tab.Screen name="Tasks"   component={TaskStack} />
       <Tab.Screen name="Profile" component={ProfileScreen} />
 
       {/* Everyone with a role can see the User dashboard */}

--- a/firebase/config.js
+++ b/firebase/config.js
@@ -1,12 +1,13 @@
-import firebase from 'firebase/compat/app';
-import 'firebase/compat/auth';
-import 'firebase/compat/firestore';
-import 'firebase/compat/storage';
 import Constants from 'expo-constants';
+import { initializeApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
 import { getFirestore } from 'firebase/firestore';
 import { getStorage } from 'firebase/storage';
 import { initializeAppCheck, ReCaptchaV3Provider } from 'firebase/app-check';
+import firebase from 'firebase/compat/app';
+import 'firebase/compat/auth';
+import 'firebase/compat/firestore';
+import 'firebase/compat/storage';
 
 // Resolve env vars from Expo config or process.env for Node tools
 const extra =
@@ -14,21 +15,21 @@ const extra =
   Constants.manifest?.extra ||
   process.env;
 
-
 const firebaseConfig = {
-  apiKey: FIREBASE_API_KEY,
-  authDomain: FIREBASE_AUTH_DOMAIN,
-  projectId: FIREBASE_PROJECT_ID,
-  storageBucket: FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: FIREBASE_MESSAGING_SENDER_ID,
-  appId: FIREBASE_APP_ID,
-  measurementId: FIREBASE_MEASUREMENT_ID,
+  apiKey: extra.FIREBASE_API_KEY,
+  authDomain: extra.FIREBASE_AUTH_DOMAIN,
+  projectId: extra.FIREBASE_PROJECT_ID,
+  storageBucket: extra.FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: extra.FIREBASE_MESSAGING_SENDER_ID,
+  appId: extra.FIREBASE_APP_ID,
+  measurementId: extra.FIREBASE_MEASUREMENT_ID,
 };
 
-// Initialize once for both compat and modular APIs
-const app = firebase.apps.length
-  ? firebase.app()
-  : firebase.initializeApp(firebaseConfig);
+// Initialize Firebase app
+const app = initializeApp(firebaseConfig);
+if (!firebase.apps.length) {
+  firebase.initializeApp(firebaseConfig);
+}
 
 // Initialize Firebase App Check in browser environments
 if (typeof window !== 'undefined') {
@@ -37,15 +38,13 @@ if (typeof window !== 'undefined') {
       provider: new ReCaptchaV3Provider(extra.RECAPTCHA_KEY),
       isTokenAutoRefreshEnabled: true,
     });
-  } catch (err) {
-    // ignore duplicate initialization errors
+  } catch {
+    // ignore duplicate initialization
   }
 }
 
-// Export compat instance for existing code
-export { firebase };
-
-// Export modular helpers for new code
+// Export app and modular helpers
+export { app, firebase };
 export const auth = getAuth(app);
 export const db = getFirestore(app);
 export const storage = getStorage(app);

--- a/navigation/AdminNavigator.js
+++ b/navigation/AdminNavigator.js
@@ -1,19 +1,53 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { Button } from 'react-native-paper';
 import AdminDashboard from '../screens/Dashboard/AdminDashboard';
 import CreateTaskScreen from '../screens/Tasks/CreateTaskScreen';
 import AssignTaskScreen from '../screens/Tasks/AssignTaskScreen';
 import TaskDetailScreen from '../screens/Tasks/TaskDetailScreen';
+import EditProfileScreen from '../screens/Profile/EditProfileScreen';
+import { AuthContext } from '../utils/auth';
 
 const Stack = createNativeStackNavigator();
 
 export default function AdminNavigator() {
+  const { role } = useContext(AuthContext);
   return (
-    <Stack.Navigator screenOptions={{ headerShown: false }}>
-      <Stack.Screen name="AdminDashboard" component={AdminDashboard} />
-      <Stack.Screen name="CreateTask" component={CreateTaskScreen} />
+    <Stack.Navigator
+      screenOptions={{
+        headerStyle: { backgroundColor: '#D32F2F' },
+        headerTintColor: '#fff',
+      }}
+    >
+      <Stack.Screen
+        name="AdminDash"
+        component={AdminDashboard}
+        options={({ navigation }) => ({
+          title: 'Admin Dashboard',
+          headerRight: () =>
+            (role === 'admin' || role === 'superadmin') ? (
+              <Button onPress={() => navigation.navigate('CreateTask')} color="#fff">
+                Create
+              </Button>
+            ) : null,
+        })}
+      />
+      <Stack.Screen
+        name="CreateTask"
+        component={CreateTaskScreen}
+        options={{ title: 'Create Task' }}
+      />
       <Stack.Screen name="AssignTask" component={AssignTaskScreen} />
-      <Stack.Screen name="TaskDetail" component={TaskDetailScreen} />
+      <Stack.Screen
+        name="TaskDetail"
+        component={TaskDetailScreen}
+        options={{ title: 'Task Detail' }}
+      />
+      <Stack.Screen
+        name="EditProfile"
+        component={EditProfileScreen}
+        options={{ title: 'Edit Profile' }}
+      />
     </Stack.Navigator>
   );
 }

--- a/navigation/ProfileStack.js
+++ b/navigation/ProfileStack.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import ProfileScreen from '../screens/ProfileScreen';
+import EditProfileScreen from '../screens/Profile/EditProfileScreen';
+
+const Stack = createNativeStackNavigator();
+
+export default function ProfileStack() {
+  return (
+    <Stack.Navigator
+      screenOptions={{
+        headerStyle: { backgroundColor: '#D32F2F' },
+        headerTintColor: '#fff',
+      }}
+    >
+      <Stack.Screen name="ProfileHome" component={ProfileScreen} options={{ title: 'Profile' }} />
+      <Stack.Screen name="EditProfile" component={EditProfileScreen} options={{ title: 'Edit Profile' }} />
+    </Stack.Navigator>
+  );
+}

--- a/navigation/TaskStack.js
+++ b/navigation/TaskStack.js
@@ -1,15 +1,14 @@
 import React, { useContext } from 'react';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { Button } from 'react-native-paper';
-import SuperAdminDashboard from '../screens/Dashboard/SuperAdminDashboard';
+import { AuthContext } from '../utils/auth';
+import TaskBoard from '../screens/Tasks/TaskBoard';
 import CreateTaskScreen from '../screens/Tasks/CreateTaskScreen';
 import TaskDetailScreen from '../screens/Tasks/TaskDetailScreen';
-import EditProfileScreen from '../screens/Profile/EditProfileScreen';
-import { AuthContext } from '../utils/auth';
 
 const Stack = createNativeStackNavigator();
 
-export default function SuperAdminNavigator() {
+export default function TaskStack() {
   const { role } = useContext(AuthContext);
   return (
     <Stack.Navigator
@@ -19,12 +18,12 @@ export default function SuperAdminNavigator() {
       }}
     >
       <Stack.Screen
-        name="SuperAdminDash"
-        component={SuperAdminDashboard}
+        name="TaskBoard"
+        component={TaskBoard}
         options={({ navigation }) => ({
-          title: 'Super Admin Dashboard',
+          title: 'Tasks',
           headerRight: () =>
-            (role === 'admin' || role === 'superadmin') ? (
+            role === 'admin' || role === 'superadmin' ? (
               <Button onPress={() => navigation.navigate('CreateTask')} color="#fff">
                 Create
               </Button>
@@ -40,11 +39,6 @@ export default function SuperAdminNavigator() {
         name="TaskDetail"
         component={TaskDetailScreen}
         options={{ title: 'Task Detail' }}
-      />
-      <Stack.Screen
-        name="EditProfile"
-        component={EditProfileScreen}
-        options={{ title: 'Edit Profile' }}
       />
     </Stack.Navigator>
   );

--- a/navigation/TaskTabs.js
+++ b/navigation/TaskTabs.js
@@ -1,2 +1,49 @@
-import RoleBasedNav from '../components/RoleBasedNav';
-export default RoleBasedNav;
+import React, { useContext } from 'react';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { Button } from 'react-native-paper';
+import TaskStack from './TaskStack';
+import ProfileStack from './ProfileStack';
+import { AuthContext } from '../utils/auth';
+
+const Tab = createBottomTabNavigator();
+
+export default function TaskTabs() {
+  const { role } = useContext(AuthContext);
+
+  return (
+    <Tab.Navigator
+      screenOptions={{
+        headerStyle: { backgroundColor: '#D32F2F' },
+        headerTintColor: '#fff',
+      }}
+    >
+      <Tab.Screen
+        name="Tasks"
+        component={TaskStack}
+        options={({ navigation }) => ({
+          headerTitle: 'Tasks',
+          headerRight: () =>
+            ['admin', 'superadmin'].includes(role) ? (
+              <Button
+                onPress={() => navigation.navigate('Tasks', { screen: 'CreateTask' })}
+                color="#fff"
+              >
+                Create
+              </Button>
+            ) : null,
+        })}
+      />
+      <Tab.Screen
+        name="Profile"
+        component={ProfileStack}
+        options={({ navigation }) => ({
+          headerRight: () => (
+            <Button onPress={() => navigation.navigate('Profile', { screen: 'EditProfile' })} color="#fff">
+              Edit
+            </Button>
+          ),
+        })}
+      />
+    </Tab.Navigator>
+  );
+}

--- a/screens/Dashboard/AdminDashboard.js
+++ b/screens/Dashboard/AdminDashboard.js
@@ -1,29 +1,33 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useContext } from 'react';
 import {
     View,
     FlatList,
-    Button,
     StyleSheet,
     ActivityIndicator
 } from 'react-native';
-import { firebase } from '../../firebase/config';
+import { FAB } from 'react-native-paper';
+import { collection, query, where, onSnapshot } from 'firebase/firestore';
+import { auth, db } from '../../firebase/config';
+import { AuthContext } from '../../utils/auth';
 import TaskCard from '../../components/TaskCard';
 
 export default function AdminDashboard({ navigation }) {
+    const { role } = useContext(AuthContext);
     const [tasks, setTasks] = useState([]);
     const [loading, setLoading] = useState(true);
 
     useEffect(() => {
-        const uid = firebase.auth().currentUser.uid;
-        const unsub = firebase
-            .firestore()
-            .collection('tasks')
-            .where('assigneeType', '==', 'admin')
-            .where('assigneeId', '==', uid)
-            .onSnapshot((snap) => {
-                setTasks(snap.docs.map((d) => ({ id: d.id, ...d.data() })));
-                setLoading(false);
-            });
+        const uid = auth.currentUser.uid;
+        // fetch tasks assigned to this admin using the modular query API
+        const q = query(
+            collection(db, 'tasks'),
+            where('assignedType', '==', 'admin'),
+            where('assignedTo', '==', uid)
+        );
+        const unsub = onSnapshot(q, (snap) => {
+            setTasks(snap.docs.map((d) => ({ id: d.id, ...d.data() })));
+            setLoading(false);
+        });
         return unsub;
     }, []);
 
@@ -39,21 +43,25 @@ export default function AdminDashboard({ navigation }) {
 
     return (
         <View style={styles.container}>
-            <Button
-                title="Create Task"
-                onPress={() => navigation.navigate('CreateTask')}
-                color="#d32f2f"
-            />
             <FlatList
                 data={tasks}
                 keyExtractor={(i) => i.id}
                 renderItem={({ item }) => <TaskCard task={item} />}
             />
+            {(role === 'admin' || role === 'superadmin') && (
+                <FAB
+                    style={styles.fab}
+                    icon="plus"
+                    label="Create Task"
+                    onPress={() => navigation.navigate('CreateTask')}
+                />
+            )}
         </View>
     );
 }
 
 const styles = StyleSheet.create({
     container: { flex: 1, padding: 10, backgroundColor: '#fff' },
-    center: { flex: 1, justifyContent: 'center', alignItems: 'center' }
+    center: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+    fab: { position: 'absolute', right: 16, bottom: 16, backgroundColor: '#d32f2f' }
 });

--- a/screens/Dashboard/UserDashboard.js
+++ b/screens/Dashboard/UserDashboard.js
@@ -7,7 +7,8 @@ import {
     ActivityIndicator
 } from 'react-native';
 import { AuthContext } from '../../utils/auth';
-import { firebase } from '../../firebase/config';
+import { collection, query, where, onSnapshot } from 'firebase/firestore';
+import { db } from '../../firebase/config';
 import TaskCard from '../../components/TaskCard';
 
 export default function UserDashboard() {
@@ -16,15 +17,15 @@ export default function UserDashboard() {
     const [loading, setLoading] = useState(true);
 
     useEffect(() => {
-        const unsub = firebase
-            .firestore()
-            .collection('tasks')
-            .where('assigneeType', '==', 'user')
-            .where('assigneeId', '==', user.uid)
-            .onSnapshot((snap) => {
-                setTasks(snap.docs.map((d) => ({ id: d.id, ...d.data() })));
-                setLoading(false);
-            });
+        const q = query(
+            collection(db, 'tasks'),
+            where('assignedType', '==', 'user'),
+            where('assignedTo', '==', user.uid)
+        );
+        const unsub = onSnapshot(q, (snap) => {
+            setTasks(snap.docs.map((d) => ({ id: d.id, ...d.data() })));
+            setLoading(false);
+        });
         return unsub;
     }, [user]);
 

--- a/screens/Profile/EditProfileScreen.js
+++ b/screens/Profile/EditProfileScreen.js
@@ -1,0 +1,111 @@
+import React, { useContext, useEffect, useState } from 'react';
+import { View, StyleSheet, Image, ScrollView } from 'react-native';
+import { TextInput, Button, Card } from 'react-native-paper';
+import * as ImagePicker from 'expo-image-picker';
+import { doc, getDoc, updateDoc } from 'firebase/firestore';
+import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
+import { AuthContext } from '../../utils/auth';
+import { db, storage } from '../../firebase/config';
+
+export default function EditProfileScreen({ navigation }) {
+  const { user } = useContext(AuthContext);
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [phone, setPhone] = useState('');
+  const [photo, setPhoto] = useState(null); // uri or url
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      const snap = await getDoc(doc(db, 'users', user.uid));
+      if (snap.exists()) {
+        const d = snap.data();
+        setFirstName(d.firstName || '');
+        setLastName(d.lastName || '');
+        setPhone(d.phone || '');
+        setPhoto(d.photoURL || null);
+      }
+      setLoading(false);
+    })();
+  }, [user]);
+
+  const pickImage = async () => {
+    const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (status !== 'granted') return;
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      allowsEditing: true,
+      quality: 0.5,
+    });
+    if (!result.canceled) {
+      setPhoto(result.assets[0].uri);
+    }
+  };
+
+  const save = async () => {
+    try {
+      setLoading(true);
+      let photoURL = photo;
+      if (photo && !photo.startsWith('https://')) {
+        const blob = await (await fetch(photo)).blob();
+        const r = ref(storage, `profilePictures/${user.uid}.jpg`);
+        await uploadBytes(r, blob);
+        photoURL = await getDownloadURL(r);
+      }
+      await updateDoc(doc(db, 'users', user.uid), {
+        firstName,
+        lastName,
+        phone,
+        photoURL,
+      });
+      navigation.goBack();
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <ScrollView contentContainerStyle={s.container}>
+      <Card style={{ padding: 16 }}>
+        {photo && (
+          <Image source={{ uri: photo }} style={s.avatar} />
+        )}
+        <Button mode="outlined" onPress={pickImage} style={{ marginBottom: 16 }}>
+          Change Photo
+        </Button>
+        <TextInput
+          label="First Name"
+          value={firstName}
+          onChangeText={setFirstName}
+          style={s.input}
+        />
+        <TextInput
+          label="Last Name"
+          value={lastName}
+          onChangeText={setLastName}
+          style={s.input}
+        />
+        <TextInput
+          label="Phone"
+          value={phone}
+          onChangeText={setPhone}
+          style={s.input}
+        />
+        <Button
+          mode="contained"
+          onPress={save}
+          loading={loading}
+          style={{ backgroundColor: '#D32F2F', marginTop: 16 }}
+        >
+          Save
+        </Button>
+      </Card>
+    </ScrollView>
+  );
+}
+
+const s = StyleSheet.create({
+  container: { padding: 16, backgroundColor: '#fff' },
+  input: { marginBottom: 12, backgroundColor: 'white' },
+  avatar: { width: 120, height: 120, borderRadius: 60, alignSelf: 'center', marginBottom: 16 },
+});

--- a/screens/ProfileScreen.js
+++ b/screens/ProfileScreen.js
@@ -1,20 +1,49 @@
-import React, { useContext } from 'react';
-import { View, Text, Button, StyleSheet } from 'react-native';
+import React, { useContext, useEffect, useState } from 'react';
+import { View, StyleSheet, Image } from 'react-native';
+import { Text, Button } from 'react-native-paper';
+import { doc, getDoc } from 'firebase/firestore';
 import { AuthContext } from '../utils/auth';
-import { firebase } from '../firebase/config';
+import { db } from '../firebase/config';
 
-export default function ProfileScreen() {
-    const { user, role } = useContext(AuthContext);
+export default function ProfileScreen({ navigation }) {
+    const { user, role, signOut } = useContext(AuthContext);
+    const [profile, setProfile] = useState(null);
 
-    const handleLogout = async () => {
-        await firebase.auth().signOut();
-    };
+    useEffect(() => {
+        (async () => {
+            if (user) {
+                const snap = await getDoc(doc(db, 'users', user.uid));
+                if (snap.exists()) setProfile(snap.data());
+            }
+        })();
+    }, [user]);
+
+    React.useLayoutEffect(() => {
+        navigation.setOptions({
+            headerRight: () => (
+                <Button onPress={() => navigation.navigate('EditProfile')} color="#fff">
+                    Edit
+                </Button>
+            )
+        });
+    }, [navigation]);
 
     return (
         <View style={styles.container}>
-            <Text style={styles.text}>Email: {user.email}</Text>
+            {profile?.photoURL && (
+                <Image source={{ uri: profile.photoURL }} style={styles.avatar} />
+            )}
+            <Text style={styles.text}>Email: {user?.email}</Text>
+            <Text style={styles.text}>Name: {profile?.firstName} {profile?.lastName}</Text>
+            <Text style={styles.text}>Phone: {profile?.phone}</Text>
             <Text style={styles.text}>Role: {role}</Text>
-            <Button title="Logout" onPress={handleLogout} color="#d32f2f" />
+            <Button
+                mode="contained"
+                onPress={signOut}
+                style={{ marginTop: 20, backgroundColor: '#d32f2f' }}
+            >
+                Logout
+            </Button>
         </View>
     );
 }
@@ -27,5 +56,6 @@ const styles = StyleSheet.create({
         padding: 20,
         backgroundColor: '#fff'
     },
-    text: { fontSize: 16, marginBottom: 12 }
+    text: { fontSize: 16, marginBottom: 12 },
+    avatar: { width: 80, height: 80, borderRadius: 40, marginBottom: 12 }
 });

--- a/screens/Tasks/CreateTaskScreen.js
+++ b/screens/Tasks/CreateTaskScreen.js
@@ -1,175 +1,28 @@
-// // screens/tasks/CreateTaskScreen.js
-// import React, { useEffect, useState, useContext } from 'react';
-// import { View, StyleSheet, TextInput, Platform, ScrollView } from 'react-native';
-// import { Text, Button, RadioButton } from 'react-native-paper';
-// import DateTimePicker from '@react-native-community/datetimepicker';
-// import { getFirestore, collection, addDoc, query, where, getDocs } from 'firebase/firestore';
-// import { AuthContext } from '../../utils/auth';
-// import sendNotification from '../../utils/sendNotification';
-
-// export default function CreateTaskScreen({ navigation }) {
-//   const db = getFirestore();
-//   const { user, role } = useContext(AuthContext);
-
-//   const [title, setTitle] = useState('');
-//   const [desc, setDesc] = useState('');
-//   const [assigneeType, setAssigneeType] = useState('user');
-//   const [admins, setAdmins] = useState([]);
-//   const [users, setUsers] = useState([]);
-//   const [selectedAdmin, setSelectedAdmin] = useState(null);
-//   const [selectedUser, setSelectedUser] = useState(null);
-//   const [deadline, setDeadline] = useState(new Date());
-//   const [showPicker, setShowPicker] = useState(false);
-
-//   useEffect(() => {
-//     // superadmin sees admins
-//     if (role === 'superadmin') {
-//       (async () => {
-//         const q = query(collection(db, 'users'), where('role', '==', 'admin'));
-//         const snap = await getDocs(q);
-//         setAdmins(snap.docs.map(d => ({ id: d.id, ...d.data() })));
-//       })();
-//     }
-//     // admin/superadmin sees their users
-//     if (role === 'admin' || role === 'superadmin') {
-//       (async () => {
-//         const q = query(collection(db, 'users'), where('adminId', '==', user.uid));
-//         const snap = await getDocs(q);
-//         setUsers(snap.docs.map(d => ({ id: d.id, ...d.data() })));
-//       })();
-//     }
-//   }, []);
-
-//   async function onSubmit() {
-//     const assigneeId = assigneeType === 'admin' ? selectedAdmin : selectedUser;
-//     if (!title || !assigneeId) return;
-
-//     const taskRef = await addDoc(collection(db, 'tasks'), {
-//       title,
-//       desc,
-//       status: 'todo',
-//       deadline,
-//       createdBy: user.uid,
-//       assignedType: assigneeType,
-//       assignedTo: assigneeId,
-//       createdAt: new Date()
-//     });
-
-//     // notify the assignee
-//     await sendNotification({
-//       userId: assigneeId,
-//       taskId: taskRef.id,
-//       type: 'assigned',
-//       message: `New task "${title}" assigned to you.`
-//     });
-
-//     // if superadmin → user, also notify that user’s admin
-//     if (role === 'superadmin' && assigneeType === 'user') {
-//       const adminOfUser = users.find(u => u.id === assigneeId)?.adminId;
-//       if (adminOfUser) {
-//         await sendNotification({
-//           userId: adminOfUser,
-//           taskId: taskRef.id,
-//           type: 'assigned',
-//           message: `Your user has a new task: "${title}".`
-//         });
-//       }
-//     }
-
-//     navigation.goBack();
-//   }
-
-//   return (
-//     <ScrollView style={s.container}>
-//       <Text style={s.header}>Create New Task</Text>
-
-//       <TextInput
-//         placeholder="Title"
-//         style={s.input}
-//         value={title} onChangeText={setTitle}
-//       />
-
-//       <TextInput
-//         placeholder="Description"
-//         style={[s.input, { height: 80 }]}
-//         value={desc} onChangeText={setDesc}
-//         multiline
-//       />
-
-//       <Text style={s.label}>Assign to:</Text>
-//       <RadioButton.Group onValueChange={setAssigneeType} value={assigneeType}>
-//         {role === 'superadmin' && (
-//           <View style={s.radioRow}>
-//             <RadioButton value="admin" /><Text>Admin</Text>
-//           </View>
-//         )}
-//         <View style={s.radioRow}>
-//           <RadioButton value="user" /><Text>User</Text>
-//         </View>
-//       </RadioButton.Group>
-
-//       {assigneeType === 'admin' && admins.map(a => (
-//         <Button
-//           key={a.id}
-//           mode={selectedAdmin === a.id ? 'contained' : 'outlined'}
-//           onPress={() => setSelectedAdmin(a.id)}
-//         >
-//           {a.name || a.email}
-//         </Button>
-//       ))}
-
-//       {assigneeType === 'user' && users.map(u => (
-//         <Button
-//           key={u.id}
-//           mode={selectedUser === u.id ? 'contained' : 'outlined'}
-//           onPress={() => setSelectedUser(u.id)}
-//         >
-//           {u.name || u.email}
-//         </Button>
-//       ))}
-
-//       <Text style={s.label}>Deadline:</Text>
-//       <Button onPress={() => setShowPicker(true)}>
-//         {deadline.toLocaleDateString()} {deadline.toLocaleTimeString()}
-//       </Button>
-//       {showPicker && (
-//         <DateTimePicker
-//           value={deadline}
-//           mode="datetime"
-//           display={Platform.OS === 'ios' ? 'spinner' : 'default'}
-//           onChange={(_, d) => {
-//             setShowPicker(Platform.OS === 'ios');
-//             if (d) setDeadline(d);
-//           }}
-//         />
-//       )}
-
-//       <Button style={s.submit} mode="contained" onPress={onSubmit}>
-//         Create Task
-//       </Button>
-//     </ScrollView>
-//   );
-// }
-
-// const s = StyleSheet.create({
-//   container: { flex: 1, padding: 16, backgroundColor: '#fafafa' },
-//   header:    { fontSize: 24, fontWeight: 'bold', marginBottom: 12, color: '#D32F2F' },
-//   label:     { marginTop: 12, fontWeight: '600' },
-//   input:     { borderWidth: 1, borderColor: '#DDD', borderRadius: 6, padding: 8, marginVertical: 6 },
-//   radioRow:  { flexDirection: 'row', alignItems: 'center', marginVertical: 4 },
-//   submit:    { marginTop: 24, backgroundColor: '#D32F2F' },
-// });
-// screens/tasks/CreateTaskScreen.js
 import React, { useEffect, useState, useContext } from 'react';
-import { View, StyleSheet, TextInput, Platform, ScrollView } from 'react-native';
-import { Text, Button, RadioButton } from 'react-native-paper';
+import {
+  View,
+  StyleSheet,
+  TextInput,
+  Platform,
+  ScrollView,
+  Text,
+  Button,
+} from 'react-native';
+import { RadioButton } from 'react-native-paper';
 import DateTimePicker from '@react-native-community/datetimepicker';
-import { getFirestore, collection, addDoc, query, where, getDocs } from 'firebase/firestore';
+import {
+  collection,
+  addDoc,
+  query,
+  where,
+  getDocs,
+  serverTimestamp,
+} from 'firebase/firestore';
+import { db } from '../../firebase/config';
 import { AuthContext } from '../../utils/auth';
 import sendNotification from '../../utils/sendNotification';
 
 export default function CreateTaskScreen({ navigation }) {
-  const db = getFirestore();
   const { user, role } = useContext(AuthContext);
 
   const [title, setTitle] = useState('');
@@ -183,23 +36,25 @@ export default function CreateTaskScreen({ navigation }) {
   const [showPicker, setShowPicker] = useState(false);
 
   useEffect(() => {
-    // superadmin sees admins
     if (role === 'superadmin') {
       (async () => {
-        const q = query(collection(db, 'users'), where('role', '==', 'admin'));
-        const snap = await getDocs(q);
-        setAdmins(snap.docs.map(d => ({ id: d.id, ...d.data() })));
+        const snap = await getDocs(query(collection(db, 'users'), where('role', '==', 'admin')));
+        setAdmins(snap.docs.map((d) => ({ id: d.id, ...d.data() })));
       })();
-    }
-    // admin/superadmin sees their users
-    if (role === 'admin' || role === 'superadmin') {
+
       (async () => {
-        const q = query(collection(db, 'users'), where('adminId', '==', user.uid));
-        const snap = await getDocs(q);
-        setUsers(snap.docs.map(d => ({ id: d.id, ...d.data() })));
+        const snap = await getDocs(query(collection(db, 'users'), where('role', '==', 'user')));
+        setUsers(snap.docs.map((d) => ({ id: d.id, ...d.data() })));
+      })();
+    } else if (role === 'admin') {
+      (async () => {
+        const snap = await getDocs(
+          query(collection(db, 'users'), where('adminId', '==', user.uid))
+        );
+        setUsers(snap.docs.map((d) => ({ id: d.id, ...d.data() })));
       })();
     }
-  }, []);
+  }, [role, user]);
 
   async function onSubmit() {
     const assigneeId = assigneeType === 'admin' ? selectedAdmin : selectedUser;
@@ -213,7 +68,7 @@ export default function CreateTaskScreen({ navigation }) {
       createdBy: user.uid,
       assignedType: assigneeType,
       assignedTo: assigneeId,
-      createdAt: new Date()
+      createdAt: serverTimestamp(),
     });
 
     // notify the assignee
@@ -269,30 +124,34 @@ export default function CreateTaskScreen({ navigation }) {
         </View>
       </RadioButton.Group>
 
-      {assigneeType === 'admin' && admins.map(a => (
-        <Button
-          key={a.id}
-          mode={selectedAdmin === a.id ? 'contained' : 'outlined'}
-          onPress={() => setSelectedAdmin(a.id)}
-        >
-          {a.name || a.email}
-        </Button>
-      ))}
+      {assigneeType === 'admin' &&
+        admins.map((a) => (
+          <View key={a.id} style={s.selectBtn}>
+            <Button
+              title={a.name || a.email}
+              color={selectedAdmin === a.id ? '#D32F2F' : undefined}
+              onPress={() => setSelectedAdmin(a.id)}
+            />
+          </View>
+        ))}
 
-      {assigneeType === 'user' && users.map(u => (
-        <Button
-          key={u.id}
-          mode={selectedUser === u.id ? 'contained' : 'outlined'}
-          onPress={() => setSelectedUser(u.id)}
-        >
-          {u.name || u.email}
-        </Button>
-      ))}
+      {assigneeType === 'user' &&
+        users.map((u) => (
+          <View key={u.id} style={s.selectBtn}>
+            <Button
+              title={u.name || u.email}
+              color={selectedUser === u.id ? '#D32F2F' : undefined}
+              onPress={() => setSelectedUser(u.id)}
+            />
+          </View>
+        ))}
 
       <Text style={s.label}>Deadline:</Text>
-      <Button onPress={() => setShowPicker(true)}>
-        {deadline.toLocaleDateString()} {deadline.toLocaleTimeString()}
-      </Button>
+      <Button
+        title={`${deadline.toLocaleDateString()} ${deadline.toLocaleTimeString()}`}
+        onPress={() => setShowPicker(true)}
+        color="#D32F2F"
+      />
       {showPicker && (
         <DateTimePicker
           value={deadline}
@@ -305,9 +164,9 @@ export default function CreateTaskScreen({ navigation }) {
         />
       )}
 
-      <Button style={s.submit} mode="contained" onPress={onSubmit}>
-        Create Task
-      </Button>
+      <View style={s.submitBtn}>
+        <Button title="Create Task" onPress={onSubmit} color="#D32F2F" />
+      </View>
     </ScrollView>
   );
 }
@@ -318,5 +177,6 @@ const s = StyleSheet.create({
   label: { marginTop: 12, fontWeight: '600' },
   input: { borderWidth: 1, borderColor: '#DDD', borderRadius: 6, padding: 8, marginVertical: 6 },
   radioRow: { flexDirection: 'row', alignItems: 'center', marginVertical: 4 },
-  submit: { marginTop: 24, backgroundColor: '#D32F2F' },
+  selectBtn: { marginVertical: 4 },
+  submitBtn: { marginTop: 24 },
 });

--- a/screens/Tasks/DraggableBoardScreen.js
+++ b/screens/Tasks/DraggableBoardScreen.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { View, ActivityIndicator, StyleSheet } from 'react-native';
-import { firebase } from '../../firebase/config';
+import { db } from '../../firebase/config';
+import { collection, onSnapshot } from 'firebase/firestore';
 import DraggableTaskBoard from '../../components/DraggableTaskBoard';
 
 export default function DraggableBoardScreen() {
@@ -8,13 +9,10 @@ export default function DraggableBoardScreen() {
     const [loading, setLoading] = useState(true);
 
     useEffect(() => {
-        const unsub = firebase
-            .firestore()
-            .collection('tasks')
-            .onSnapshot((snap) => {
-                setTasks(snap.docs.map((d) => ({ id: d.id, ...d.data() })));
-                setLoading(false);
-            });
+        const unsub = onSnapshot(collection(db, 'tasks'), (snap) => {
+            setTasks(snap.docs.map((d) => ({ id: d.id, ...d.data() })));
+            setLoading(false);
+        });
         return unsub;
     }, []);
 

--- a/screens/Tasks/TaskBoard.js
+++ b/screens/Tasks/TaskBoard.js
@@ -6,7 +6,8 @@ import {
   StyleSheet,
   ActivityIndicator
 } from 'react-native';
-import { firebase } from '../../firebase/config';
+import { collection, onSnapshot } from 'firebase/firestore';
+import { db } from '../../firebase/config';
 import TaskCard from '../../components/TaskCard';
 
 export default function TaskBoard({ navigation }) {
@@ -14,19 +15,17 @@ export default function TaskBoard({ navigation }) {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const unsub = firebase
-      .firestore()
-      .collection('tasks')
-      .onSnapshot(
-        (snap) => {
-          setTasks(snap.docs.map((d) => ({ id: d.id, ...d.data() })));
-          setLoading(false);
-        },
-        (err) => {
-          console.warn(err);
-          setLoading(false);
-        }
-      );
+    const unsub = onSnapshot(
+      collection(db, 'tasks'),
+      (snap) => {
+        setTasks(snap.docs.map((d) => ({ id: d.id, ...d.data() })));
+        setLoading(false);
+      },
+      (err) => {
+        console.warn(err);
+        setLoading(false);
+      }
+    );
     return unsub;
   }, []);
 

--- a/screens/Tasks/TaskDetailScreen.js
+++ b/screens/Tasks/TaskDetailScreen.js
@@ -1,104 +1,95 @@
-import React, { useState, useEffect, useContext } from 'react';
-import {
-  View,
-  Text,
-  Button,
-  TextInput,
-  StyleSheet,
-  ActivityIndicator,
-  Alert
-} from 'react-native';
-import { firebase } from '../../firebase/config';
-import sendNotification from '../../utils/sendNotification';
-
+import React, { useEffect, useState, useContext } from 'react';
+import { View, Text, StyleSheet, ScrollView, Button, ActivityIndicator, Alert } from 'react-native';
+import { doc, getDoc, updateDoc } from 'firebase/firestore';
 import { AuthContext } from '../../utils/auth';
+import { db } from '../../firebase/config';
 import sendNotification from '../../utils/sendNotification';
 
 export default function TaskDetailScreen({ route, navigation }) {
   const { taskId } = route.params;
-  const db = getFirestore();
-  const { user, role } = useContext(AuthContext);
-
+  const { user } = useContext(AuthContext);
   const [task, setTask] = useState(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const sub = firebase
-      .firestore()
-      .collection('tasks')
-      .doc(taskId)
-      .onSnapshot((d) => setTask({ id: d.id, ...d.data() }));
-    return sub;
+    (async () => {
+      try {
+        const snap = await getDoc(doc(db, 'tasks', taskId));
+        if (snap.exists()) {
+          setTask({ id: snap.id, ...snap.data() });
+        }
+      } catch (e) {
+        Alert.alert('Error', 'Failed to load task');
+      } finally {
+        setLoading(false);
+      }
+    })();
   }, [taskId]);
 
-  const updateStatus = async (action) => {
+  async function changeStatus(newStatus) {
     if (!task) return;
     try {
       setLoading(true);
-      const newStatus =
-        action === 'accept'
-          ? 'inprogress'
-          : action === 'complete'
-          ? 'done'
-          : task.status;
-      await firebase
-        .firestore()
-        .collection('tasks')
-        .doc(taskId)
-        .update({
-          status: newStatus,
-          remarks: firebase.firestore.FieldValue.arrayUnion({
-            by: user.uid,
-            text: remarks,
-            at: firebase.firestore.FieldValue.serverTimestamp()
-          })
-        });
-      await sendNotification({
-        userId: task.createdBy,
-        type: action,
-        taskId,
-        message: `${user.email} ${action}ed "${task.title}"`,
-      });
-      await logAction(`${action}Task`, { taskId, action });
+      await updateDoc(doc(db, 'tasks', taskId), { status: newStatus });
+      setTask((t) => ({ ...t, status: newStatus }));
+
+      const message = `Task "${task.title}" is now ${newStatus}`;
+      await sendNotification({ userId: task.createdBy, taskId, type: 'status', message });
+      if (task.assignedTo) {
+        await sendNotification({ userId: task.assignedTo, taskId, type: 'status', message });
+      }
     } catch (e) {
-      Alert.alert('Error', e.message);
+      Alert.alert('Error', 'Failed to update task');
     } finally {
       setLoading(false);
-
     }
-
-    navigation.goBack();
   }
+
+  if (loading) {
+    return (
+      <View style={s.center}><ActivityIndicator size="large" color="#d32f2f" /></View>
+    );
+  }
+  if (!task) {
+    return (
+      <View style={s.center}><Text>Task not found.</Text></View>
+    );
+  }
+
+  const isAssignee = user?.uid === task.assignedTo;
+  const isCreator = user?.uid === task.createdBy;
 
   return (
     <ScrollView style={s.container}>
-      <Card>
-        <Card.Title
-          title={task.title}
-          subtitle={`Status: ${task.status.toUpperCase()}`}
-        />
-        <Card.Content>
-          <Text>Description:</Text>
-          <Text>{task.desc}</Text>
-          <Text>Deadline: {task.deadline.toDate().toLocaleString()}</Text>
-          <Text>Assigned by: {task.createdBy}</Text>
-          <Text>Assigned to: {task.assignedTo}</Text>
-        </Card.Content>
-        <Card.Actions>
-          {isAssignee && task.status === 'todo' && (
+      <Text style={s.title}>{task.title}</Text>
+      <Text style={s.label}>Description:</Text>
+      <Text>{task.desc}</Text>
+      <Text style={s.label}>Deadline:</Text>
+      <Text>{task.deadline?.toDate().toLocaleString()}</Text>
+      <Text style={s.label}>Status:</Text>
+      <Text>{task.status}</Text>
+
+      {task.status === 'todo' && (
+        <View style={s.actions}>
+          {isAssignee && (
             <>
-              <Button onPress={() => changeStatus('inprogress')}>Start</Button>
-              <Button onPress={() => changeStatus('done')}>Complete</Button>
+              <Button title="Start" onPress={() => changeStatus('inprogress')} />
+              <Button title="Complete" onPress={() => changeStatus('done')} />
             </>
           )}
-          {isCreator && task.status === 'todo' && (
-            <Button onPress={() => changeStatus('cancelled')}>Cancel</Button>
+          {isCreator && (
+            <Button title="Cancel" onPress={() => changeStatus('cancelled')} />
           )}
-        </Card.Actions>
-      </Card>
+        </View>
+      )}
     </ScrollView>
   );
 }
 
 const s = StyleSheet.create({
   container: { flex: 1, padding: 16, backgroundColor: '#fff' },
+  title: { fontSize: 20, fontWeight: 'bold', marginBottom: 12 },
+  label: { marginTop: 12, fontWeight: '600' },
+  actions: { marginTop: 24 },
+  center: { flex: 1, justifyContent: 'center', alignItems: 'center' }
 });

--- a/utils/audit.js
+++ b/utils/audit.js
@@ -1,4 +1,5 @@
-import { firebase } from '../firebase/config';
+import { auth, db } from '../firebase/config';
+import { collection, addDoc, serverTimestamp } from 'firebase/firestore';
 
 /**
  * Log every important action to /auditLogs.
@@ -6,14 +7,11 @@ import { firebase } from '../firebase/config';
  * @param {object} details  e.g. { taskId, to: userId }
  */
 export async function logAction(action, details = {}) {
-    const uid = firebase.auth().currentUser.uid;
-    await firebase
-        .firestore()
-        .collection('auditLogs')
-        .add({
-            action,
-            by: uid,
-            at: firebase.firestore.FieldValue.serverTimestamp(),
-            details,
-        });
+    const uid = auth.currentUser.uid;
+    await addDoc(collection(db, 'auditLogs'), {
+        action,
+        by: uid,
+        at: serverTimestamp(),
+        details,
+    });
 }

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -1,53 +1,55 @@
 import React, { createContext, useState, useEffect } from 'react';
-import { firebase, auth, db } from '../firebase/config';
-import { onAuthStateChanged } from 'firebase/auth';
-import { doc, getDoc } from 'firebase/firestore';
+import {
+  getAuth,
+  onAuthStateChanged,
+  signOut as fbSignOut,
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
+  sendEmailVerification,
+  reload,
+} from 'firebase/auth';
+import { getFirestore, doc, getDoc } from 'firebase/firestore';
+import app from '../firebase/config';
 
-export const AuthContext = createContext();
+const auth = getAuth(app);
+const db = getFirestore(app);
+
+export const AuthContext = createContext({ user: null, role: null, loading: true });
 
 /**
  * Wrap your app in <AuthProvider> to get { user, role, loading } everywhere.
  */
 export function AuthProvider({ children }) {
     const [user, setUser] = useState(null);
-    const [role, setRole] = useState('');
+    const [role, setRole] = useState(null);
     const [loading, setLoading] = useState(true);
 
     useEffect(() => {
         // Listen for auth state changes using modular API
         const unsubscribe = onAuthStateChanged(auth, async (u) => {
-            setUser(u);
             if (u) {
-                // Load role from Firestore
-                try {
-                    const snap = await getDoc(doc(db, 'users', u.uid));
-                    setRole(snap.exists() ? snap.data().role || '' : '');
-                } catch {
-                    setRole('');
-                }
+                setUser(u);
+                const snap = await getDoc(doc(db, 'users', u.uid));
+                const data = snap.exists() ? snap.data() : {};
+                setRole(data.role || 'user');
             } else {
-                setRole('');
+                setUser(null);
+                setRole(null);
             }
             setLoading(false);
         });
         return unsubscribe;
     }, []);
 
+    const signOut = () => fbSignOut(auth);
+
     return (
-        <AuthContext.Provider value={{ user, role, loading }}>
+        <AuthContext.Provider value={{ user, role, loading, signOut }}>
             {children}
         </AuthContext.Provider>
     );
 }
 
-
-import {
-    signInWithEmailAndPassword,
-    createUserWithEmailAndPassword,
-    sendEmailVerification,
-    reload,
-    signOut,
-} from 'firebase/auth';
 
 /** Subscribe to auth changes; returns unsubscribe() */
 export function listenAuth(cb) {
@@ -80,5 +82,6 @@ export function reloadCurrentUser() {
 
 /** Sign out */
 export function logout() {
-    return signOut(auth);
+    return fbSignOut(auth);
 }
+

--- a/utils/notifications.js
+++ b/utils/notifications.js
@@ -1,5 +1,6 @@
 import * as Notifications from 'expo-notifications';
-import { firebase } from '../firebase/config';
+import { auth, db } from '../firebase/config';
+import { doc, updateDoc } from 'firebase/firestore';
 import { Platform } from 'react-native';
 
 /**
@@ -24,12 +25,8 @@ export async function registerForPushNotificationsAsync() {
     const token = tokenData.data;
 
     // Save to Firestore
-    const uid = firebase.auth().currentUser.uid;
-    await firebase
-        .firestore()
-        .collection('users')
-        .doc(uid)
-        .update({ fcmToken: token });
+    const uid = auth.currentUser.uid;
+    await updateDoc(doc(db, 'users', uid), { fcmToken: token });
 
     // Android only: set channel
     if (Platform.OS === 'android') {

--- a/utils/sendNotification.js
+++ b/utils/sendNotification.js
@@ -1,9 +1,11 @@
-import { firebase } from '../firebase/config';
+import { httpsCallable, getFunctions } from 'firebase/functions';
+import { app } from '../firebase/config';
 
 /**
  * Call the `sendNotification` Cloud Function.
  * @param {{userId: string, type: string, taskId: string, message: string}} payload
  */
 export default function sendNotification(payload) {
-  return firebase.functions().httpsCallable('sendNotification')(payload);
+  const fn = httpsCallable(getFunctions(app), 'sendNotification');
+  return fn(payload);
 }


### PR DESCRIPTION
## Summary
- retrieve role after setting user in AuthProvider
- add edit profile flow and display profile details
- create ProfileStack with Profile and EditProfile screens
- show Create button conditionally in Admin/SuperAdmin dashboards
- show Create and Edit header actions in TaskTabs

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686d161657c0832a8c560dea8dfd2d0b